### PR TITLE
R03-傑銘-Passport (local + jwt)

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -8,8 +8,8 @@ const ExtractJWT = passportJWT.ExtractJwt
 
 passport.use(new LocalStrategy(
   {
-    usernameField: 'account',
-    passwordField: 'password'
+    // 因為只有usernameField變成account，所以只改這個
+    usernameField: 'account'
   },
   (account, password, cb) => {
     User.findOne({ where: { account } })
@@ -26,6 +26,16 @@ passport.use(new LocalStrategy(
       .catch(error => cb(error))
   }
 ))
+
+const jwtOptions = {
+  jwtFromRequest: ExtractJWT.fromAuthHeaderAsBearerToken(),
+  secretOrKey: process.env.JWT_SECRET
+}
+passport.use(new JWTStrategy(jwtOptions, (jwtPayload, cb) => {
+  User.findByPk(jwtPayload.id)
+    .then(user => cb(null, user))
+    .catch(err => cb(err))
+}))
 
 passport.serializeUser((user, cb) => {
   cb(null, user.id)

--- a/config/passport.js
+++ b/config/passport.js
@@ -1,5 +1,39 @@
 const passport = require('passport')
+const LocalStrategy = require('passport-local')
+const passportJWT = require('passport-jwt')
+const bcrypt = require('bcryptjs')
+const { User } = require('../models')
+const JWTStrategy = passportJWT.Strategy
+const ExtractJWT = passportJWT.ExtractJwt
 
+passport.use(new LocalStrategy(
+  {
+    usernameField: 'account',
+    passwordField: 'password'
+  },
+  (account, password, cb) => {
+    User.findOne({ where: { account } })
+      .then(user => {
+        // 如果使用者不存在
+        if (!user) return cb(null, false, { message: '帳號或密碼輸入錯誤!' })
+        // 如果使用者密碼錯誤
+        bcrypt.compare(password, user.password).then(res => {
+          if (!res) return cb(null, false, { message: '帳號或密碼輸入錯誤!' })
+        })
+        // 認證成功，回傳user資訊
+        return cb(null, user, { message: '登入成功!' })
+      })
+      .catch(error => cb(error))
+  }
+))
 
+passport.serializeUser((user, cb) => {
+  cb(null, user.id)
+})
+passport.deserializeUser((id, cb) => {
+  return User.findByPk(id)
+    .then(user => cb(null, user.toJSON()))
+    .catch(err => cb(err))
+})
 
 module.exports = passport


### PR DESCRIPTION
1. .env裡面的 JWT_SECRET=alphacamp
2. 檔案位置: config/passport.js
3. 改usernameField為 ‘account’，而passwordField預設為password就沒有改動
4. then() 回傳的user，我目前只有放user本身的資料，之後要再加的話可以放include去抓取其他model的資料
5. 進行了unauthorized優化後，在 Postman 實驗時會出現以下來自authenticatedAdmin的錯誤訊息：{
    "status": "error",
    "message": "permission denied"
}

所以 next() 改成
req.logIn(user, function(err) {
      if (err) { return next(err); }
      return res.send(user);
    })