### PR TITLE
R11-傑銘-根據test修正model、安裝cross-env執行script

### DIFF
--- a/models/like.js
+++ b/models/like.js
@@ -10,7 +10,8 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate (models) {
-      // define association here
+      Like.belongsTo(models.User, { foreignKey: 'userId' })
+      Like.belongsTo(models.Tweet, { foreignKey: 'tweetId' })
     }
   };
   Like.init({

--- a/models/like.js
+++ b/models/like.js
@@ -15,6 +15,11 @@ module.exports = (sequelize, DataTypes) => {
     }
   };
   Like.init({
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true
+    },
     UserId: DataTypes.INTEGER,
     TweetId: DataTypes.INTEGER
   }, {

--- a/models/tweet.js
+++ b/models/tweet.js
@@ -12,6 +12,7 @@ module.exports = (sequelize, DataTypes) => {
     static associate (models) {
       Tweet.belongsTo(models.User, { foreignKey: 'userId' })
       Tweet.hasMany(models.Reply, { foreignKey: 'tweetId' })
+      Tweet.hasMany(models.Like, { foreignKey: 'tweetId' })
       Tweet.belongsToMany(models.User, {
         through: models.Like,
         foreignKey: 'tweetId',

--- a/models/user.js
+++ b/models/user.js
@@ -12,6 +12,7 @@ module.exports = (sequelize, DataTypes) => {
     static associate (models) {
       User.hasMany(models.Tweet, { foreignKey: 'userId' })
       User.hasMany(models.Reply, { foreignKey: 'userId' })
+      User.hasMany(models.Like, { foreignKey: 'userId' })
       User.belongsToMany(models.Tweet, {
         through: models.Like,
         foreignKey: 'userId',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1003,6 +1003,14 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1933,7 +1941,7 @@
     "faker": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
-      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
+      "integrity": "sha512-ILKg69P6y/D8/wSmDXw35Ly0re8QzQ8pMfBCflsGiZG2ZjMUNLYNexA6lz5pkmJlepVdsiDFUxYAzPQ9/+iGLA=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "start": "NODE_ENV=development node app.js",
-    "dev": "NODE_ENV=development nodemon app.js",
+    "start": "cross-env NODE_ENV=development node app.js",
+    "dev": "cross-env NODE_ENV=development nodemon app.js",
     "lint": "eslint \"**/*.js\" --fix",
-    "test": "mocha test --exit --recursive --timeout 5000"
+    "test": "cross-env NODE_ENV=test mocha test --exit --recursive --timeout 5000"
   },
   "author": "",
   "license": "ISC",
@@ -17,8 +17,14 @@
     "body-parser": "^1.18.3",
     "chai": "^4.2.0",
     "connect-flash": "^0.1.1",
+    "cross-env": "^7.0.3",
     "dayjs": "^1.10.6",
     "dotenv": "^10.0.0",
+    "eslint": "^7.32.0",
+    "eslint-config-standard": "^16.0.3",
+    "eslint-plugin-import": "^2.23.4",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^5.1.0",
     "express": "^4.17.1",
     "express-session": "^1.17.2",
     "faker": "^4.1.0",
@@ -33,12 +39,7 @@
     "sequelize": "^6.6.5",
     "sequelize-cli": "^6.2.0",
     "sinon": "^10.0.0",
-    "sinon-chai": "^3.3.0",
-    "eslint": "^7.32.0",
-    "eslint-config-standard": "^16.0.3",
-    "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^5.1.0"
+    "sinon-chai": "^3.3.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.20",


### PR DESCRIPTION
- 有增加漏掉的關聯
- 安裝 npm install cross-env
- 在package.json裡script的 start, dev, test 前面加上 cross-env (因為原本的script的指令只能讓linux操作，裝了cross-env就可以讓不同系統都可執行)
- 哭RRRRRR

一直在找Like為何不會通過測試，花了大概兩三個小時，原因是測試檔取不到id
試了很久終於在這篇文章找到類似的討論
[https://github.com/sequelize/sequelize/issues/7689#issuecomment-698244276](https://github.com/sequelize/sequelize/issues/7689#issuecomment-698244276)

發現應該是跟join table有點關係，我把id加到models/like.js 裡的 18:22 行
手動設定id為primary key，就可以通過測試了