### PR TITLE
R13-傑銘-解決app.js無法run的問題

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,15 +1,23 @@
-const express = require('express')
-const helpers = require('./_helpers')
+if (process.env.NODE_ENV !== 'production') {
+  require('dotenv').config()
+}
 
+const express = require('express')
+const { helpers, getUser } = require('./_helpers')
+const session = require('express-session')
+const passport = require('./config/passport')
 const { apis } = require('./routes')
 
 const app = express()
 const port = process.env.PORT || 3000
 
-// use helpers.getUser(req) to replace req.user
-function authenticated (req, res, next) {
-  // passport.authenticate('jwt', { ses...
-};
+const SESSION_SECRET = 'secret'
+
+app.use(express.urlencoded({ extended: true }))
+app.use(express.json())
+app.use(session({ secret: SESSION_SECRET, resave: false, saveUninitialized: false }))
+app.use(passport.initialize())
+app.use(passport.session())
 
 app.use('/api', apis)
 app.listen(port, () => console.log(`Example app listening on port ${port}!`))

--- a/routes/apis/index.js
+++ b/routes/apis/index.js
@@ -4,8 +4,8 @@ const router = express.Router()
 const admin = require('./modules/admin')
 const users = require('./modules/users')
 
-const { authenticated, authenticatedAdmin } = require('../middleware/api-auth')
-const { apiErrorHandler } = require('../middleware/error-handler')
+const { authenticated, authenticatedAdmin } = require('../../middleware/api-auth')
+const { apiErrorHandler } = require('../../middleware/error-handler')
 
 router.use('/admin', authenticated, authenticatedAdmin, admin)
 router.use('/users', authenticated, users)

--- a/routes/apis/modules/tweets.js
+++ b/routes/apis/modules/tweets.js
@@ -1,16 +1,16 @@
 const express = require('express')
-const route = express.Router()
+const router = express.Router()
 
 const tweetController = require('../../../controllers/tweet-controller')
 
-route.get('/:tweetId/replies', tweetController.getReplies)
-route.post('/:tweetId/replies', tweetController.postReply)
-route.get('/:tweetId', tweetController.getTweet)
+router.get('/:tweetId/replies', tweetController.getReplies)
+router.post('/:tweetId/replies', tweetController.postReply)
+router.get('/:tweetId', tweetController.getTweet)
 
-route.post('/tweetId/like', tweetController.addLike)
-route.post('/tweetId/unlike', tweetController.removeLike)
+router.post('/tweetId/like', tweetController.addLike)
+router.post('/tweetId/unlike', tweetController.removeLike)
 
-route.post('/', tweetController.postTweet)
-route.get('/', tweetController.getTweets)
+router.post('/', tweetController.postTweet)
+router.get('/', tweetController.getTweets)
 
-module.exports = route
+module.exports = router

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,3 +1,3 @@
 const apis = require('./apis')
 
-module.exports = apis
+module.exports = { apis }


### PR DESCRIPTION
- 解決一些typo
- 參照餐廳論壇教案比對，app.js多加了些middleware，如果不小心多加畫面相關的，之後再刪除掉

- routes/index.js 的 module.exports = { apis }

在 app.js中，const { apis } = require('./routes') 是這樣寫
所以在 routes/index.js 裡的 module.exports = { apis } 要用 {} 來裝
不然app.js 會抓不到 apis

另一種寫法可以是
app.js:   const apis = require('./routes')
routes/index.js:    module.exports = apis