### PR TITLE
R26-傑銘-express-rate-limit

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,12 +5,21 @@ if (process.env.NODE_ENV !== 'production') {
 const express = require('express')
 const session = require('express-session')
 const cors = require('cors')
+const rateLimit = require('express-rate-limit')
 const passport = require('./config/passport')
 const { apis } = require('./routes')
 
 const app = express()
 const port = process.env.PORT || 3000
 
+const limiter = rateLimit({
+  windowMs: 5 * 60 * 1000,
+  max: 100,
+  message: 'Too many requests, please try again later!'
+})
+
+app.use(limiter)
+app.set('trust proxy', 1)
 app.use(cors())
 app.use(express.urlencoded({ extended: true }))
 app.use(express.json())

--- a/package-lock.json
+++ b/package-lock.json
@@ -2032,6 +2032,11 @@
         }
       }
     },
+    "express-rate-limit": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.7.0.tgz",
+      "integrity": "sha512-vhwIdRoqcYB/72TK3tRZI+0ttS8Ytrk24GfmsxDXK9o9IhHNO5bXRiXQSExPQ4GbaE5tvIS7j1SGrxsuWs+sGA=="
+    },
     "express-session": {
       "version": "1.17.2",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.2.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
     "express": "^4.17.1",
+    "express-rate-limit": "^6.7.0",
     "express-session": "^1.17.2",
     "express-validator": "^6.15.0",
     "faker": "^4.1.0",


### PR DESCRIPTION
參照[此網址](https://medium.com/easons-murmuring/express%E7%AD%86%E8%A8%98-%E4%BD%BF%E7%94%A8-express-rate-limit-%E4%BE%86%E9%99%90%E5%88%B6%E4%BE%86%E8%87%AA%E5%90%8C%E4%B8%80ip%E7%9A%84%E9%87%8D%E8%A4%87%E8%AB%8B%E6%B1%82-2dac638c1a42)實作express-rate-limit
就可以避免IP一次打太多請求，壓縮heroku使用3600次的限制